### PR TITLE
Java Client: Add fine granted permissions for role-by-id and identity providers

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/IdentityProviderResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/IdentityProviderResource.java
@@ -17,9 +17,7 @@
 
 package org.keycloak.admin.client.resource;
 
-import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
-import org.keycloak.representations.idm.IdentityProviderMapperTypeRepresentation;
-import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.*;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -83,4 +81,15 @@ public interface IdentityProviderResource {
     @DELETE
     @Path("mappers/{id}")
     void delete(@PathParam("id") String id);
+
+    @GET
+    @Path("management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions();
+
+    @PUT
+    @Path("management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(ManagementPermissionRepresentation status);
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleByIdResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/RoleByIdResource.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.admin.client.resource;
 
+import org.keycloak.representations.idm.ManagementPermissionReference;
+import org.keycloak.representations.idm.ManagementPermissionRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 
 import javax.ws.rs.Consumes;
@@ -87,4 +89,14 @@ public interface RoleByIdResource {
     @Consumes(MediaType.APPLICATION_JSON)
     void deleteComposites(final @PathParam("role-id") String id, List<RoleRepresentation> roles);
 
+    @GET
+    @Path("{role-id}/management/permissions")
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference getPermissions(final @PathParam("role-id") String id);
+
+    @PUT
+    @Path("{role-id}/management/permissions")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    ManagementPermissionReference setPermissions(final @PathParam("role-id") String id, ManagementPermissionRepresentation status);
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ManagementPermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ManagementPermissionsTest.java
@@ -18,10 +18,7 @@ package org.keycloak.testsuite.admin;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.GroupResource;
-import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.admin.client.resource.RoleResource;
+import org.keycloak.admin.client.resource.*;
 import org.keycloak.common.Profile;
 import org.keycloak.representations.idm.*;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
@@ -255,6 +252,117 @@ public class ManagementPermissionsTest extends AbstractTestRealmKeycloakTest {
         assertNotNull(result);
         assertFalse(result.isEnabled());
         result = roleResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+    }
+
+    @Test
+    public void updateRealmRoleByIdPermissions() {
+        RealmResource realmResource = adminClient.realms().realm("test");
+        RoleRepresentation roleRepresentation = new RoleRepresentation();
+        roleRepresentation.setName("perm-role-test");
+        realmResource.roles().create(roleRepresentation);
+
+        String roleId = realmResource.roles().get("perm-role-test").toRepresentation().getId();
+
+        RoleByIdResource roleResource = realmResource.rolesById();
+
+        ManagementPermissionReference result = roleResource.setPermissions(roleId, new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions(roleId);
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(roleId, new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions(roleId);
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = roleResource.setPermissions(roleId, new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions(roleId);
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(roleId, new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = roleResource.getPermissions(roleId);
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = roleResource.setPermissions(roleId, new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions(roleId);
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = roleResource.setPermissions(roleId, new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = roleResource.getPermissions(roleId);
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+    }
+
+    @Test
+    public void updateIdentityProviderPermissions() {
+        RealmResource realmResource = adminClient.realms().realm("test");
+
+        IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
+        idp.setAlias("perm-idp-test");
+        idp.setDisplayName("perm-idp-test");
+        idp.setProviderId("oidc");
+        idp.setEnabled(true);
+
+        realmResource.identityProviders().create(idp);
+
+        IdentityProviderResource identityProviderResource = realmResource.identityProviders().get("perm-idp-test");
+
+        ManagementPermissionReference result = identityProviderResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = identityProviderResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = identityProviderResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = identityProviderResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = identityProviderResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = identityProviderResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = identityProviderResource.setPermissions(new ManagementPermissionRepresentation(true));
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+        result = identityProviderResource.getPermissions();
+        assertNotNull(result);
+        assertTrue(result.isEnabled());
+
+        result = identityProviderResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = identityProviderResource.getPermissions();
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+
+        result = identityProviderResource.setPermissions(new ManagementPermissionRepresentation(false));
+        assertNotNull(result);
+        assertFalse(result.isEnabled());
+        result = identityProviderResource.getPermissions();
         assertNotNull(result);
         assertFalse(result.isEnabled());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ManagementPermissionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/ManagementPermissionsTest.java
@@ -260,10 +260,10 @@ public class ManagementPermissionsTest extends AbstractTestRealmKeycloakTest {
     public void updateRealmRoleByIdPermissions() {
         RealmResource realmResource = adminClient.realms().realm("test");
         RoleRepresentation roleRepresentation = new RoleRepresentation();
-        roleRepresentation.setName("perm-role-test");
+        roleRepresentation.setName("perm-role-id-test");
         realmResource.roles().create(roleRepresentation);
 
-        String roleId = realmResource.roles().get("perm-role-test").toRepresentation().getId();
+        String roleId = realmResource.roles().get("perm-role-id-test").toRepresentation().getId();
 
         RoleByIdResource roleResource = realmResource.rolesById();
 


### PR DESCRIPTION
Includes a getter to retreive the current status of the fine grain permission feature for identity providers as well as a setter to enable/disable the permissions.

Follow up of https://github.com/keycloak/keycloak/pull/5571.